### PR TITLE
view members with public profiles on rwandaopensource:

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,14 @@ import express from 'express';
 import HomeRouter from './modules/home';
 import GithubRouter from './modules/github';
 import StatsRouter from './modules/stats';
+import MembersRouter from './modules/members';
+
 
 const App = express.Router();
 
 App.use(GithubRouter);
 App.use(StatsRouter);
+App.use(MembersRouter);
 App.use(HomeRouter);
 
 export default App;

--- a/src/helpers/github.members.ts
+++ b/src/helpers/github.members.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+/**
+ * Github helper class, use for managing API called in github
+ * @export default
+ * @class GithubHelper
+ */
+export default class GithubMembers {
+  /**
+ * Get all members of Public members of Rwanda Open Source
+ * return -1 when some error occured
+ * @static
+ * @returns {array} github user accounts
+ * @memberof GithubMembers
+ */
+  static async viewAllPublicMembers(): Promise<number> {
+    try {
+      const URL = 'https://api.github.com/orgs/rwandaopensource/members';
+      const response = await axios.get(URL);
+      return response.data;
+    } catch (err) {
+      console.error(Date.now().toString(), err.message);
+      return 0;
+    }
+  }
+}

--- a/src/modules/members/controller.ts
+++ b/src/modules/members/controller.ts
@@ -1,0 +1,10 @@
+import GithubMembers from '../../helpers/github.members';
+
+export default class MembersController {
+  static async viewMembers(req: any, res: any) {
+    const members = await GithubMembers.viewAllPublicMembers();
+    res.status(200).json({
+      members,
+    });
+  }
+}

--- a/src/modules/members/index.ts
+++ b/src/modules/members/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import Controller from './controller';
+
+const MembersRouter = express.Router();
+
+MembersRouter.get('/members', Controller.viewMembers);
+
+export default MembersRouter;

--- a/src/modules/members/tests/members.test.ts
+++ b/src/modules/members/tests/members.test.ts
@@ -1,0 +1,19 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../../app';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+describe('Test for members', () => {
+  it('should return array of members', done => {
+    chai.request(app)
+      .get('/members')
+      .end((err, res) => {
+        const { body, status } = res;
+        expect(status).to.eql(200);
+        expect(body).to.be.an('array');
+      });
+    done();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
* Enables users to see all public profiles of rwanda open source communitye
#### Description of Task to be completed?
* add help to get all the public profile from github.
* add a /members route for one to view members
* add tests
#### How should this be manually tested?
* clone this repo
* run `npm run start:dev`
* access this `/members` route on your local host
#### Any background context you want to provide?
* N/A
#### What are the relevant pivotal tracker stories?
[ #8 ](https://github.com/rwandaopensource/backend.opensource.org.rw/issues/8)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30793016/79071910-7114e480-7cde-11ea-8c12-9d4466a59e29.png)
#### Questions: